### PR TITLE
Moved module XML file to modules folder

### DIFF
--- a/app/etc/modules/Web_Rules.xml
+++ b/app/etc/modules/Web_Rules.xml
@@ -6,7 +6,6 @@
             <codePool>local</codePool>
             <depends>
                 <Mage_CatalogRule/>
-
             </depends>
         </Web_Rules>
     </modules>


### PR DESCRIPTION
According to the Magento folder layout a modules XML file should reside in `app/etc/modules/`.
